### PR TITLE
Update MenuExtension.php

### DIFF
--- a/Twig/MenuExtension.php
+++ b/Twig/MenuExtension.php
@@ -166,9 +166,9 @@ class MenuExtension extends AbstractExtension
                 }
             }
 
-            $attr .= sprintf('%s="%s"', $key, $value);
+            $attr .= sprintf('%s="%s" ', $key, $value);
         }
 
-        return $attr;
+        return trim($attr);
     }
 }


### PR DESCRIPTION
Without spaces, the attributes stick to each other, e.g.
`<a href="#" class="nav-link"id="navbarDropdownMenuLink"data-toggle="dropdown" ...`