### PR TITLE
Make private vars protected so we can extend classes

### DIFF
--- a/Builder/Item.php
+++ b/Builder/Item.php
@@ -21,82 +21,82 @@ class Item implements ItemInterface
     /**
      * @var int
      */
-    private $id;
+    protected $id;
 
     /**
      * @var string
      */
-    private $label = '';
+    protected $label = '';
 
     /**
      * @var string
      */
-    private $labelAfterHtml = '';
+    protected $labelAfterHtml = '';
 
     /**
      * @var string
      */
-    private $link = '';
+    protected $link = '';
 
     /**
      * @var string
      */
-    private $linkAfterHtml = '';
+    protected $linkAfterHtml = '';
 
     /**
      * @var int
      */
-    private $order;
+    protected $order;
 
     /**
      * @var array
      */
-    private $route = [];
+    protected $route = [];
 
     /**
      * @var array
      */
-    private $linkAttr = [];
+    protected $linkAttr = [];
 
     /**
      * @var array
      */
-    private $listAttr = [];
+    protected $listAttr = [];
 
     /**
      * @var array
      */
-    private $childAttr = [];
+    protected $childAttr = [];
 
     /**
      * @var array
      */
-    private $labelAttr = [];
+    protected $labelAttr = [];
 
     /**
      * @var array
      */
-    private $extra = [];
+    protected $extra = [];
 
     /**
      * @var array
      */
-    private $roles = [];
+    protected $roles = [];
 
     /**
      * @var ItemInterface[]
      */
-    private $child = [];
+    protected $child = [];
 
     /**
      * @var null | ItemInterface
      */
-    private $parent;
+    protected $parent;
 
     /**
      * @var bool
      */
-    private $event;
+    protected $event;
 
     /**
      * Item constructor.

--- a/Builder/ItemProcess.php
+++ b/Builder/ItemProcess.php
@@ -26,22 +26,22 @@ class ItemProcess implements ItemProcessInterface
     /**
      * @var RouterInterface
      */
-    private $router;
+    protected $router;
 
     /**
      * @var AuthorizationCheckerInterface
      */
-    private $security;
+    protected $security;
 
     /**
      * @var EventDispatcherInterface
      */
-    private $eventDispatcher;
+    protected $eventDispatcher;
 
     /**
      * @var string
      */
-    private $currentUri;
+    protected $currentUri;
 
     /**
      * ItemProcess constructor.
@@ -89,7 +89,7 @@ class ItemProcess implements ItemProcessInterface
      *
      * @return bool
      */
-    private function recursiveProcess(ItemInterface $menu, $options)
+    protected function recursiveProcess(ItemInterface $menu, $options)
     {
         // Get Child Menus
         $childs = $menu->getChild();


### PR DESCRIPTION
This is one way of fixing #1 by allowing users to extend the Item class and use that in creating their menus.